### PR TITLE
Fix +0 Adding 1

### DIFF
--- a/dicey-math/anydice-cache.json
+++ b/dicey-math/anydice-cache.json
@@ -22504,5 +22504,25 @@
 			"maxY": 6.00387231367
 		},
 		"query": "output d6d6"
+	},
+	"output 1+0": {
+		"distributions": {
+			"data": [
+				[
+					[
+						1,
+						100
+					]
+				]
+			],
+			"labels": [
+				"output 1"
+			],
+			"minX": 1,
+			"maxX": 1,
+			"minY": 0,
+			"maxY": 100
+		},
+		"query": "output 1+0"
 	}
 }

--- a/dicey-math/anydice.test.js
+++ b/dicey-math/anydice.test.js
@@ -71,6 +71,7 @@ anytest("100d6");
 anytest("300d6");
 anytest("500d6");
 
+anytest("1+0");
 anytest("500/10/5");
 anytest("2+2*2");
 anytest("2*2+2");

--- a/dicey-math/parser.js
+++ b/dicey-math/parser.js
@@ -4,6 +4,15 @@ module.exports = `
   function math(l,o) {
      let v = l;
      for (let i = 0; i < o.length; i++) {
+       v = {type: 'math', right: o[i][3], left: v};
+       if (typeof(o[i][1]) == "string") v.op = o[i][1];
+       else Object.assign(v, o[i][1]);
+     }
+     return v;
+  }
+    function implicitMath(l,o) { // For DropLowest et al., there may or may not be an operand so assume 1 by default.
+     let v = l;
+     for (let i = 0; i < o.length; i++) {
        v = {type: 'math', right: o[i][3] || 1, left: v};
        if (typeof(o[i][1]) == "string") v.op = o[i][1];
        else Object.assign(v, o[i][1]);
@@ -52,7 +61,7 @@ P1Bin = l:P2Bin o:(WS e:Compare WS r:P2Bin)* { return math(l,o) } / P2Bin
 P2Bin = l:P3Bin o:(WS e:[+-] WS r:P3Bin)* { return math(l,o); } / P3Bin
 P3Bin = l:P4Bin o:(WS e:[*/] WS r:P4Bin)* { return math(l,o) } / P4Bin
 P4Bin = 
-  l:Primary o:(WS e:(DropLow/DropHigh/KeepLow/KeepHigh/'@') WS r:Primary?)* { return math(l,o) } /
+  l:Primary o:(WS e:(DropLow/DropHigh/KeepLow/KeepHigh/'@') WS r:Primary?)* { return implicitMath(l,o) } /
   Primary
 
 DropLow = ('droplow'i / 'dl'i) { return 'dl'; } 


### PR DESCRIPTION
math() in parser now assumes 2 operands, I created 'implicitMath()' for when there's an optional second operand. 
Prevents 0 triggering a null check and defaulting to 1. Includes unit test.

#3 